### PR TITLE
fix: hide toolbox button when printing

### DIFF
--- a/src/skins/ipe-default.css
+++ b/src/skins/ipe-default.css
@@ -664,6 +664,12 @@
   z-index: 199;
 }
 
+@media print {
+  #ipe-edit-toolbox {
+    display: none;
+  }
+}
+
 #ipe-edit-toolbox .ipe-toolbox-btn {
   color: white;
   background: #bebebe;


### PR DESCRIPTION
This allows users to print a page without having to disable IPE first.