### PR TITLE
fix(ipe-default.css): box-sizing of ssi-topIcons

### DIFF
--- a/src/skins/ipe-default.css
+++ b/src/skins/ipe-default.css
@@ -68,7 +68,7 @@
 
 .in-page-edit .ssi-topIcons {
   text-align: center;
-  box-sizing:  content-box;
+  box-sizing: content-box;
 }
 
 .in-page-edit .ssi-topIcons .ssi-closeIcon {

--- a/src/skins/ipe-default.css
+++ b/src/skins/ipe-default.css
@@ -68,6 +68,7 @@
 
 .in-page-edit .ssi-topIcons {
   text-align: center;
+  box-sizing:  content-box;
 }
 
 .in-page-edit .ssi-topIcons .ssi-closeIcon {


### PR DESCRIPTION
Suggested by @gui-ying233