### PR TITLE
feat(cm6): prepare for TemplateStyles customization

### DIFF
--- a/src/plugins/code-mirror/cm6.js
+++ b/src/plugins/code-mirror/cm6.js
@@ -28,7 +28,7 @@ mw.hook('InPageEdit').add(() =>
       const ext = page.getExtension()?.toLowerCase()
       const isSubject = namespace % 2 === 0
       if (ext === 'css' && isSubject) {
-        return 'css'
+        return [2, 8, 2300].includes(namespace) ? 'css' : 'sanitized-css'
       } else if (ext === 'js' && isSubject) {
         return 'javascript'
       } else if (ext === 'json' && isSubject) {


### PR DESCRIPTION
CM6高亮即将针对TemplateStyles调整Stylelint设置和自动填充提示。

## Sourcery 总结

新特性：
- 仅为指定的命名空间返回完整的 CSS 模式，并在 CM6 高亮显示期间，默认为其他命名空间返回 sanitized-css。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

New Features:
- Return full CSS mode only for designated namespaces and default to sanitized-css for others during CM6 highlighting

</details>