### PR TITLE
更新CodeMirror插件说明

### DIFF
--- a/src/index-v2.json
+++ b/src/index-v2.json
@@ -32,7 +32,7 @@
   },
   {
     "_id": "code-mirror-5",
-    "title": "CodeMirror 5",
+    "title": "[DEPRECATED] CodeMirror 5",
     "description": "Syntaxhighlight editor for InPageEdit. Currently supported languages: Wikitext, CSS, JavaScript, JSON, Lua. In conflict with CodeMirror 6.",
     "author": "InPageEdit",
     "scripts": [
@@ -41,7 +41,7 @@
   },
   {
     "_id": "code-mirror-6",
-    "title": "[BETA] CodeMirror 6",
+    "title": "CodeMirror 6",
     "description": "Syntaxhighlight editor for InPageEdit. Currently supported languages: Wikitext, CSS, JavaScript, JSON, Lua. [!] In conflict with CodeMirror 5.",
     "author": "InPageEdit",
     "scripts": [

--- a/src/index-v2.json
+++ b/src/index-v2.json
@@ -42,7 +42,7 @@
   {
     "_id": "code-mirror-6",
     "title": "CodeMirror 6",
-    "description": "Syntaxhighlight editor for InPageEdit. Currently supported languages: Wikitext, CSS, JavaScript, JSON, Lua. [!] In conflict with CodeMirror 5.",
+    "description": "Syntaxhighlight editor for InPageEdit. Currently supported languages: Wikitext, CSS, JavaScript, JSON, Lua, Vue. [!] In conflict with CodeMirror 5.",
     "author": "InPageEdit",
     "scripts": [
       "code-mirror/cm6.js"

--- a/src/index.json
+++ b/src/index.json
@@ -19,12 +19,12 @@
     "author": "dragon-fish"
   },
   "code-mirror/script.js": {
-    "name": "CodeMirror 5",
+    "name": "[DEPRECATED] CodeMirror 5",
     "description": "Syntaxhighlight editor for InPageEdit. Currently supported languages: Wikitext, CSS, JavaScript, JSON, Lua. In conflict with CodeMirror 6.",
     "author": "InPageEdit"
   },
   "code-mirror/cm6.js": {
-    "name": "[BETA] CodeMirror 6",
+    "name": "CodeMirror 6",
     "description": "Syntaxhighlight editor for InPageEdit. Currently supported languages: Wikitext, CSS, JavaScript, JSON, Lua. [!] In conflict with CodeMirror 5.",
     "author": "InPageEdit"
   },

--- a/src/index.json
+++ b/src/index.json
@@ -25,7 +25,7 @@
   },
   "code-mirror/cm6.js": {
     "name": "CodeMirror 6",
-    "description": "Syntaxhighlight editor for InPageEdit. Currently supported languages: Wikitext, CSS, JavaScript, JSON, Lua. [!] In conflict with CodeMirror 5.",
+    "description": "Syntaxhighlight editor for InPageEdit. Currently supported languages: Wikitext, CSS, JavaScript, JSON, Lua, Vue. [!] In conflict with CodeMirror 5.",
     "author": "InPageEdit"
   },
   "monaco/script.js": {


### PR DESCRIPTION
CodeMirror 6已经稳定，并废弃CodeMirror 5。

## Sourcery 总结

文档:
- 修改索引文件中的 CodeMirror 插件描述，以注明 CodeMirror 6 的稳定性以及 CodeMirror 5 的弃用

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Documentation:
- Revise CodeMirror plugin descriptions in index files to note CodeMirror 6 stability and deprecation of CodeMirror 5

</details>