### PR TITLE
fix(cm6.js): do not load CM6 unconditionally

### DIFF
--- a/src/plugins/code-mirror/cm6.js
+++ b/src/plugins/code-mirror/cm6.js
@@ -14,11 +14,6 @@ mw.hook('InPageEdit').add(() =>
 
     mw.loader.load(`${PLUGIN_CDN}/plugins/code-mirror/style.css`, 'text/css')
 
-    await Promise.all([
-      mw.loader.using('mediawiki.Title'),
-      window.CodeMirror6 || import(`${CM_CDN}/dist/mw.min.js`),
-    ])
-
     /**
      * 检查页面语言类型
      * @param page Page title
@@ -81,6 +76,11 @@ mw.hook('InPageEdit').add(() =>
      */
     mw.hook('InPageEdit.quickEdit').add(({ $editArea, $modalTitle }) =>
       (async () => {
+        await Promise.all([
+          mw.loader.using('mediawiki.Title'),
+          window.CodeMirror6 || import(`${CM_CDN}/dist/mw.min.js`),
+        ])
+
         const page = new mw.Title($modalTitle.find('.editPage').text())
         const cm = await renderEditor($editArea, page)
         mw.hook('InPageEdit.quickEdit.codemirror6').fire({ $editArea, cm })


### PR DESCRIPTION
fix #62

## Sourcery 概要

延迟导入 CodeMirror6 及其依赖项，直到快速编辑模式被激活，以避免在初始页面加载时加载不必要的资源。

错误修复：
- 通过延迟导入 CodeMirror6，防止其在页面加载时无条件加载

改进：
- 当快速编辑钩子被调用时，按需加载 mediawiki.Title 和 CodeMirror6 的依赖项

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Delay importing CodeMirror6 and its dependencies until quick edit mode is activated to avoid unnecessary asset loading on initial page load

Bug Fixes:
- Prevent unconditional loading of CodeMirror6 on page load by deferring its import

Enhancements:
- Lazy-load mediawiki.Title and CodeMirror6 dependencies when the quick edit hook is invoked

</details>